### PR TITLE
add convenient Patches constructor

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -50,6 +50,10 @@ func create() *Patches {
 	return &Patches{originals: make(map[reflect.Value][]byte), values: make(map[reflect.Value]reflect.Value)}
 }
 
+func NewPatches() *Patches {
+	return create()
+}
+
 func (this *Patches) ApplyFunc(target, double interface{}) *Patches {
 	t := reflect.ValueOf(target)
 	d := reflect.ValueOf(double)


### PR DESCRIPTION
Currently there is no way to construct Patches object to pass different doubles for different targets, e.g. :

```go
patchFuncs := [][2]interface{}{
	{
		amqp.Dial,
		func(url string) (*amqp.Connection, error) {
			return nil, testAmqpDialError
		},
	},
	{
		lepus.SyncChannel,
		func(*amqp.Channel, error) (*lepus.Channel, error) {
			return nil, testAmqpChannelError
		},
	}
}

patches := new(gomonkey.Patches) // will not call make unexported maps
for _, patchPair := range patchFuncs {
	patches.ApplyFunc(pair[0], pair[1]) // will panic "assignment to nil map"
}
defer patches.Reset()
```

With this simple wrapper around `create()` func it will be possible:

```go
patches := gomonkey.NewPatches() // will call make on unexported maps
for _, patchPair := range patchFuncs {
	patches.ApplyFunc(pair[0], pair[1]) // will not panic
}
defer patches.Reset()
```