### PR TITLE
新增支持指定返回值和method不用传入receiver

### DIFF
--- a/test/apply_func_return_test.go
+++ b/test/apply_func_return_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2/test/fake"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+/*
+  compare with apply_func_seq_test.go
+*/
+func TestApplyFuncReturn(t *testing.T) {
+	Convey("TestApplyFuncReturn", t, func() {
+
+		Convey("declares the values to be returned", func() {
+			info1 := "hello cpp"
+
+			patches := ApplyFuncReturn(fake.ReadLeaf, info1, nil)
+			defer patches.Reset()
+
+			for i := 0; i < 10; i++ {
+				output, err := fake.ReadLeaf("")
+				So(err, ShouldEqual, nil)
+				So(output, ShouldEqual, info1)
+			}
+
+			patches.Reset() // if not reset will occur:patch has been existed
+			info2 := "hello golang"
+			patches.ApplyFuncReturn(fake.ReadLeaf, info2, nil)
+			for i := 0; i < 10; i++ {
+				output, err := fake.ReadLeaf("")
+				So(err, ShouldEqual, nil)
+				So(output, ShouldEqual, info2)
+			}
+		})
+	})
+}

--- a/test/apply_func_var_return_test.go
+++ b/test/apply_func_var_return_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2/test/fake"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+/*
+  compare with apply_func_var_seq_test.go
+*/
+func TestApplyFuncVarReturn(t *testing.T) {
+	Convey("TestApplyFuncVarReturn", t, func() {
+
+		Convey("declares the values to be returned", func() {
+			info1 := "hello cpp"
+
+			patches := ApplyFuncVarReturn(&fake.Marshal, []byte(info1), nil)
+			defer patches.Reset()
+			for i := 0; i < 10; i++ {
+				bytes, err := fake.Marshal("")
+				So(err, ShouldEqual, nil)
+				So(string(bytes), ShouldEqual, info1)
+			}
+
+			info2 := "hello golang"
+			patches.ApplyFuncVarReturn(&fake.Marshal, []byte(info2), nil)
+			for i := 0; i < 10; i++ {
+				bytes, err := fake.Marshal("")
+				So(err, ShouldEqual, nil)
+				So(string(bytes), ShouldEqual, info2)
+			}
+		})
+
+	})
+}

--- a/test/apply_method_func_test.go
+++ b/test/apply_method_func_test.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2/test/fake"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+/*
+	compare with apply_method_test.go, no need pass receiver
+*/
+
+func TestApplyMethodFunc(t *testing.T) {
+	slice := fake.NewSlice()
+	var s *fake.Slice
+	Convey("TestApplyMethodFunc", t, func() {
+		Convey("for succ", func() {
+			err := slice.Add(1)
+			So(err, ShouldEqual, nil)
+			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+				return nil
+			})
+			defer patches.Reset()
+			err = slice.Add(1)
+			So(err, ShouldEqual, nil)
+			err = slice.Remove(1)
+			So(err, ShouldEqual, nil)
+			So(len(slice), ShouldEqual, 0)
+		})
+
+		Convey("for already exist", func() {
+			err := slice.Add(2)
+			So(err, ShouldEqual, nil)
+			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+				return fake.ErrElemExsit
+			})
+			defer patches.Reset()
+			err = slice.Add(1)
+			So(err, ShouldEqual, fake.ErrElemExsit)
+			err = slice.Remove(2)
+			So(err, ShouldEqual, nil)
+			So(len(slice), ShouldEqual, 0)
+		})
+
+		Convey("two methods", func() {
+			err := slice.Add(3)
+			So(err, ShouldEqual, nil)
+			defer slice.Remove(3)
+			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+				return fake.ErrElemExsit
+			})
+			defer patches.Reset()
+			patches.ApplyMethodFunc(reflect.TypeOf(s), "Remove", func(_ int) error {
+				return fake.ErrElemNotExsit
+			})
+			err = slice.Add(2)
+			So(err, ShouldEqual, fake.ErrElemExsit)
+			err = slice.Remove(1)
+			So(err, ShouldEqual, fake.ErrElemNotExsit)
+			So(len(slice), ShouldEqual, 1)
+			So(slice[0], ShouldEqual, 3)
+		})
+
+		Convey("one func and one method", func() {
+			err := slice.Add(4)
+			So(err, ShouldEqual, nil)
+			defer slice.Remove(4)
+			patches := ApplyFunc(fake.Exec, func(_ string, _ ...string) (string, error) {
+				return outputExpect, nil
+			})
+			defer patches.Reset()
+			patches.ApplyMethodFunc(reflect.TypeOf(s), "Remove", func(_ int) error {
+				return fake.ErrElemNotExsit
+			})
+			output, err := fake.Exec("", "")
+			So(err, ShouldEqual, nil)
+			So(output, ShouldEqual, outputExpect)
+			err = slice.Remove(1)
+			So(err, ShouldEqual, fake.ErrElemNotExsit)
+			So(len(slice), ShouldEqual, 1)
+			So(slice[0], ShouldEqual, 4)
+		})
+	})
+}

--- a/test/apply_method_return_test.go
+++ b/test/apply_method_return_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2/test/fake"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+/*
+   compare with apply_method_seq_test.go
+*/
+
+func TestApplyMethodReturn(t *testing.T) {
+	e := &fake.Etcd{}
+	Convey("TestApplyMethodReturn", t, func() {
+		Convey("declares the values to be returned", func() {
+			info1 := "hello cpp"
+			patches := ApplyMethodReturn(e, "Retrieve", info1, nil)
+			defer patches.Reset()
+			for i := 0; i < 10; i++ {
+				output1, err1 := e.Retrieve("")
+				So(err1, ShouldEqual, nil)
+				So(output1, ShouldEqual, info1)
+			}
+
+			patches.Reset() // if not reset will occur:patch has been existed
+			info2 := "hello golang"
+			patches.ApplyMethodReturn(e, "Retrieve", info2, nil)
+			for i := 0; i < 10; i++ {
+				output2, err2 := e.Retrieve("")
+				So(err2, ShouldEqual, nil)
+				So(output2, ShouldEqual, info2)
+			}
+		})
+	})
+}


### PR DESCRIPTION
支持func/var/method指定返回值,参考test/:
apply_func_return_test.go
apply_func_var_return_test.go
apply_method_return_test.go
支持method打桩时不传入receiver,参考test/:
apply_method_func_test.go