### PR TITLE
passing target no need to convert to reflect.Type

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -24,15 +24,15 @@ func ApplyFunc(target, double interface{}) *Patches {
 	return create().ApplyFunc(target, double)
 }
 
-func ApplyMethod(target reflect.Type, methodName string, double interface{}) *Patches {
+func ApplyMethod(target interface{}, methodName string, double interface{}) *Patches {
 	return create().ApplyMethod(target, methodName, double)
 }
 
-func ApplyMethodFunc(target reflect.Type, methodName string, doubleFunc interface{}) *Patches {
+func ApplyMethodFunc(target interface{}, methodName string, doubleFunc interface{}) *Patches {
 	return create().ApplyMethodFunc(target, methodName, doubleFunc)
 }
 
-func ApplyPrivateMethod(target reflect.Type, methodName string, double interface{}) *Patches {
+func ApplyPrivateMethod(target interface{}, methodName string, double interface{}) *Patches {
 	return create().ApplyPrivateMethod(target, methodName, double)
 }
 
@@ -48,7 +48,7 @@ func ApplyFuncSeq(target interface{}, outputs []OutputCell) *Patches {
 	return create().ApplyFuncSeq(target, outputs)
 }
 
-func ApplyMethodSeq(target reflect.Type, methodName string, outputs []OutputCell) *Patches {
+func ApplyMethodSeq(target interface{}, methodName string, outputs []OutputCell) *Patches {
 	return create().ApplyMethodSeq(target, methodName, outputs)
 }
 
@@ -82,8 +82,8 @@ func (this *Patches) ApplyFunc(target, double interface{}) *Patches {
 	return this.ApplyCore(t, d)
 }
 
-func (this *Patches) ApplyMethod(target reflect.Type, methodName string, double interface{}) *Patches {
-	m, ok := target.MethodByName(methodName)
+func (this *Patches) ApplyMethod(target interface{}, methodName string, double interface{}) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
 	if !ok {
 		panic("retrieve method by name failed")
 	}
@@ -91,8 +91,8 @@ func (this *Patches) ApplyMethod(target reflect.Type, methodName string, double 
 	return this.ApplyCore(m.Func, d)
 }
 
-func (this *Patches) ApplyMethodFunc(target reflect.Type, methodName string, doubleFunc interface{}) *Patches {
-	m, ok := target.MethodByName(methodName)
+func (this *Patches) ApplyMethodFunc(target interface{}, methodName string, doubleFunc interface{}) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
 	if !ok {
 		panic("retrieve method by name failed")
 	}
@@ -100,8 +100,8 @@ func (this *Patches) ApplyMethodFunc(target reflect.Type, methodName string, dou
 	return this.ApplyCore(m.Func, d)
 }
 
-func (this *Patches) ApplyPrivateMethod(target reflect.Type, methodName string, double interface{}) *Patches {
-	m, ok := creflect.MethodByName(target, methodName)
+func (this *Patches) ApplyPrivateMethod(target interface{}, methodName string, double interface{}) *Patches {
+	m, ok := creflect.MethodByName(castRType(target), methodName)
 	if !ok {
 		panic("retrieve method by name failed")
 	}
@@ -138,8 +138,8 @@ func (this *Patches) ApplyFuncSeq(target interface{}, outputs []OutputCell) *Pat
 	return this.ApplyCore(t, d)
 }
 
-func (this *Patches) ApplyMethodSeq(target reflect.Type, methodName string, outputs []OutputCell) *Patches {
-	m, ok := target.MethodByName(methodName)
+func (this *Patches) ApplyMethodSeq(target interface{}, methodName string, outputs []OutputCell) *Patches {
+	m, ok := castRType(target).MethodByName(methodName)
 	if !ok {
 		panic("retrieve method by name failed")
 	}
@@ -337,4 +337,11 @@ func funcToMethod(funcType reflect.Type, doubleFunc interface{}) reflect.Value {
 	return reflect.MakeFunc(funcType, func(in []reflect.Value) []reflect.Value {
 		return vf.Call(in[1:])
 	})
+}
+
+func castRType(val interface{}) reflect.Type {
+	if rTypeVal, ok := val.(reflect.Type); ok {
+		return rTypeVal
+	}
+	return reflect.TypeOf(val)
 }

--- a/test/apply_interface_reused_test.go
+++ b/test/apply_interface_reused_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"reflect"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -21,7 +20,7 @@ func TestApplyInterfaceReused(t *testing.T) {
 
 		Convey("TestApplyInterface", func() {
 			info := "hello interface"
-			patches.ApplyMethod(reflect.TypeOf(e), "Retrieve",
+			patches.ApplyMethod(e, "Retrieve",
 				func(_ *fake.Etcd, _ string) (string, error) {
 					return info, nil
 				})
@@ -39,7 +38,7 @@ func TestApplyInterfaceReused(t *testing.T) {
 				{Values: Params{info2, nil}},
 				{Values: Params{info3, nil}},
 			}
-			patches.ApplyMethodSeq(reflect.TypeOf(e), "Retrieve", outputs)
+			patches.ApplyMethodSeq(e, "Retrieve", outputs)
 			output, err := db.Retrieve("")
 			So(err, ShouldEqual, nil)
 			So(output, ShouldEqual, info1)

--- a/test/apply_method_func_test.go
+++ b/test/apply_method_func_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"reflect"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -20,7 +19,7 @@ func TestApplyMethodFunc(t *testing.T) {
 		Convey("for succ", func() {
 			err := slice.Add(1)
 			So(err, ShouldEqual, nil)
-			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+			patches := ApplyMethodFunc(s, "Add", func(_ int) error {
 				return nil
 			})
 			defer patches.Reset()
@@ -34,7 +33,7 @@ func TestApplyMethodFunc(t *testing.T) {
 		Convey("for already exist", func() {
 			err := slice.Add(2)
 			So(err, ShouldEqual, nil)
-			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+			patches := ApplyMethodFunc(s, "Add", func(_ int) error {
 				return fake.ErrElemExsit
 			})
 			defer patches.Reset()
@@ -49,11 +48,11 @@ func TestApplyMethodFunc(t *testing.T) {
 			err := slice.Add(3)
 			So(err, ShouldEqual, nil)
 			defer slice.Remove(3)
-			patches := ApplyMethodFunc(reflect.TypeOf(s), "Add", func(_ int) error {
+			patches := ApplyMethodFunc(s, "Add", func(_ int) error {
 				return fake.ErrElemExsit
 			})
 			defer patches.Reset()
-			patches.ApplyMethodFunc(reflect.TypeOf(s), "Remove", func(_ int) error {
+			patches.ApplyMethodFunc(s, "Remove", func(_ int) error {
 				return fake.ErrElemNotExsit
 			})
 			err = slice.Add(2)
@@ -72,7 +71,7 @@ func TestApplyMethodFunc(t *testing.T) {
 				return outputExpect, nil
 			})
 			defer patches.Reset()
-			patches.ApplyMethodFunc(reflect.TypeOf(s), "Remove", func(_ int) error {
+			patches.ApplyMethodFunc(s, "Remove", func(_ int) error {
 				return fake.ErrElemNotExsit
 			})
 			output, err := fake.Exec("", "")

--- a/test/apply_method_seq_test.go
+++ b/test/apply_method_seq_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"reflect"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -22,7 +21,7 @@ func TestApplyMethodSeq(t *testing.T) {
 				{Values: Params{info2, nil}},
 				{Values: Params{info3, nil}},
 			}
-			patches := ApplyMethodSeq(reflect.TypeOf(e), "Retrieve", outputs)
+			patches := ApplyMethodSeq(e, "Retrieve", outputs)
 			defer patches.Reset()
 			output, err := e.Retrieve("")
 			So(err, ShouldEqual, nil)
@@ -41,7 +40,7 @@ func TestApplyMethodSeq(t *testing.T) {
 				{Values: Params{"", fake.ErrActual}, Times: 2},
 				{Values: Params{info1, nil}},
 			}
-			patches := ApplyMethodSeq(reflect.TypeOf(e), "Retrieve", outputs)
+			patches := ApplyMethodSeq(e, "Retrieve", outputs)
 			defer patches.Reset()
 			output, err := e.Retrieve("")
 			So(err, ShouldEqual, fake.ErrActual)
@@ -58,7 +57,7 @@ func TestApplyMethodSeq(t *testing.T) {
 				{Values: Params{info1, nil}, Times: 2},
 				{Values: Params{"", fake.ErrActual}},
 			}
-			patches := ApplyMethodSeq(reflect.TypeOf(e), "Retrieve", outputs)
+			patches := ApplyMethodSeq(e, "Retrieve", outputs)
 			defer patches.Reset()
 			output, err := e.Retrieve("")
 			So(err, ShouldEqual, nil)

--- a/test/apply_method_test.go
+++ b/test/apply_method_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"reflect"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -17,7 +16,7 @@ func TestApplyMethod(t *testing.T) {
 		Convey("for succ", func() {
 			err := slice.Add(1)
 			So(err, ShouldEqual, nil)
-			patches := ApplyMethod(reflect.TypeOf(s), "Add", func(_ *fake.Slice, _ int) error {
+			patches := ApplyMethod(s, "Add", func(_ *fake.Slice, _ int) error {
 				return nil
 			})
 			defer patches.Reset()
@@ -31,7 +30,7 @@ func TestApplyMethod(t *testing.T) {
 		Convey("for already exist", func() {
 			err := slice.Add(2)
 			So(err, ShouldEqual, nil)
-			patches := ApplyMethod(reflect.TypeOf(s), "Add", func(_ *fake.Slice, _ int) error {
+			patches := ApplyMethod(s, "Add", func(_ *fake.Slice, _ int) error {
 				return fake.ErrElemExsit
 			})
 			defer patches.Reset()
@@ -46,11 +45,11 @@ func TestApplyMethod(t *testing.T) {
 			err := slice.Add(3)
 			So(err, ShouldEqual, nil)
 			defer slice.Remove(3)
-			patches := ApplyMethod(reflect.TypeOf(s), "Add", func(_ *fake.Slice, _ int) error {
+			patches := ApplyMethod(s, "Add", func(_ *fake.Slice, _ int) error {
 				return fake.ErrElemExsit
 			})
 			defer patches.Reset()
-			patches.ApplyMethod(reflect.TypeOf(s), "Remove", func(_ *fake.Slice, _ int) error {
+			patches.ApplyMethod(s, "Remove", func(_ *fake.Slice, _ int) error {
 				return fake.ErrElemNotExsit
 			})
 			err = slice.Add(2)
@@ -69,7 +68,7 @@ func TestApplyMethod(t *testing.T) {
 				return outputExpect, nil
 			})
 			defer patches.Reset()
-			patches.ApplyMethod(reflect.TypeOf(s), "Remove", func(_ *fake.Slice, _ int) error {
+			patches.ApplyMethod(s, "Remove", func(_ *fake.Slice, _ int) error {
 				return fake.ErrElemNotExsit
 			})
 			output, err := fake.Exec("", "")

--- a/test/apply_private_method_test.go
+++ b/test/apply_private_method_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
     "github.com/agiledragon/gomonkey/v2/test/fake"
-    "reflect"
     "testing"
 
     . "github.com/agiledragon/gomonkey/v2"
@@ -14,7 +13,7 @@ func TestApplyPrivateMethod(t *testing.T) {
         Convey("patch private pointer method in the different package", func() {
             f := new(fake.PrivateMethodStruct)
             var s *fake.PrivateMethodStruct
-            patches := ApplyPrivateMethod(reflect.TypeOf(s), "ok", func(_ *fake.PrivateMethodStruct) bool {
+            patches := ApplyPrivateMethod(s, "ok", func(_ *fake.PrivateMethodStruct) bool {
                 return false
             })
             defer patches.Reset()
@@ -24,7 +23,7 @@ func TestApplyPrivateMethod(t *testing.T) {
 
         Convey("patch private value method in the different package", func() {
             s := fake.PrivateMethodStruct{}
-            patches := ApplyPrivateMethod(reflect.TypeOf(s), "haveEaten", func(_ fake.PrivateMethodStruct) bool {
+            patches := ApplyPrivateMethod(s, "haveEaten", func(_ fake.PrivateMethodStruct) bool {
                 return false
             })
             defer patches.Reset()


### PR DESCRIPTION
passing target no need to convert to reflect.Type  and also backward  compatibility