### PR TITLE
Solve the issue on the Darwin ARM64 architecture where the step of flushing the instruction cache is missing after modifying machine code.

### DIFF
--- a/modify_binary_darwin.go
+++ b/modify_binary_darwin.go
@@ -21,4 +21,5 @@ func modifyBinary(target uintptr, bytes []byte) {
 
 //go:cgo_import_dynamic mach_task_self mach_task_self "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic mach_vm_protect mach_vm_protect "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic sys_icache_invalidate sys_icache_invalidate "/usr/lib/libSystem.B.dylib"
 func write(target, data uintptr, len int, page uintptr, pageSize, oriProt int) int

--- a/write_darwin_arm64.s
+++ b/write_darwin_arm64.s
@@ -56,6 +56,11 @@ PROTECT_OK:
     MOVD    pageSize+32(FP), R1
     MOVD    oriProt+40(FP), R2
     SVC     $0x80
+    MOVD    R0, R27           // Save return value of mprotect
+    MOVD    target+0(FP), R0  // Arg1: start address
+    MOVD    len+16(FP), R1    // Arg2: length
+    CALL    sys_icache_invalidate(SB)
+    MOVD    R27, R0           // Restore return value
     B       RETURN
     NOP16384
 RETURN:


### PR DESCRIPTION
Solve the issue on the Darwin ARM64 architecture where the step of flushing the instruction cache is missing after modifying machine code.