### PR TITLE
fix(darwin): expand mprotect range when patch crosses a page boundary

### DIFF
--- a/modify_binary_darwin.go
+++ b/modify_binary_darwin.go
@@ -13,7 +13,12 @@ func PtrOf(val []byte) uintptr {
 
 func modifyBinary(target uintptr, bytes []byte) {
 	targetPage := pageStart(target)
-	res := write(target, PtrOf(bytes), len(bytes), targetPage, syscall.Getpagesize(), syscall.PROT_READ|syscall.PROT_EXEC)
+	endPage := pageStart(target + uintptr(len(bytes)) - 1)
+	protectSize := syscall.Getpagesize()
+	if endPage > targetPage {
+		protectSize = int(endPage-targetPage) + syscall.Getpagesize()
+	}
+	res := write(target, PtrOf(bytes), len(bytes), targetPage, protectSize, syscall.PROT_READ|syscall.PROT_EXEC)
 	if res != 0 {
 		panic(fmt.Errorf("failed to write memory, code %v", res))
 	}

--- a/modify_binary_darwin.go
+++ b/modify_binary_darwin.go
@@ -13,15 +13,24 @@ func PtrOf(val []byte) uintptr {
 
 func modifyBinary(target uintptr, bytes []byte) {
 	targetPage := pageStart(target)
-	endPage := pageStart(target + uintptr(len(bytes)) - 1)
-	protectSize := syscall.Getpagesize()
-	if endPage > targetPage {
-		protectSize = int(endPage-targetPage) + syscall.Getpagesize()
-	}
-	res := write(target, PtrOf(bytes), len(bytes), targetPage, protectSize, syscall.PROT_READ|syscall.PROT_EXEC)
+	res := write(target, PtrOf(bytes), len(bytes), targetPage,
+		protectSize(target, len(bytes)), syscall.PROT_READ|syscall.PROT_EXEC)
 	if res != 0 {
 		panic(fmt.Errorf("failed to write memory, code %v", res))
 	}
+}
+
+// protectSize returns the number of bytes that must be made writable so that a
+// patch of n bytes starting at target is fully covered, even when the patch
+// spans a page boundary.
+func protectSize(target uintptr, n int) int {
+	targetPage := pageStart(target)
+	endPage := pageStart(target + uintptr(n) - 1)
+	size := syscall.Getpagesize()
+	if endPage > targetPage {
+		size = int(endPage-targetPage) + syscall.Getpagesize()
+	}
+	return size
 }
 
 //go:cgo_import_dynamic mach_task_self mach_task_self "/usr/lib/libSystem.B.dylib"

--- a/modify_binary_darwin_test.go
+++ b/modify_binary_darwin_test.go
@@ -1,0 +1,70 @@
+package gomonkey
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// A 24-byte jmp patch that begins close to the end of a page must make both
+// the current and the next page writable, otherwise writing it triggers SIGBUS
+// (see issue #186).
+func TestProtectSizeAcrossPageBoundary(t *testing.T) {
+	ps := syscall.Getpagesize()
+	base := uintptr(ps * 4) // any page-aligned address
+
+	cases := []struct {
+		name   string
+		target uintptr
+		n      int
+		want   int
+	}{
+		{"patch fully inside one page", base + 16, 24, ps},
+		{"patch ends on the last byte of the page", base + uintptr(ps) - 24, 24, ps},
+		{"24-byte patch starts 16 bytes before boundary", base + uintptr(ps) - 16, 24, 2 * ps},
+		{"patch starts on the very last byte", base + uintptr(ps) - 1, 24, 2 * ps},
+	}
+	for _, c := range cases {
+		if got := protectSize(c.target, c.n); got != c.want {
+			t.Errorf("%s: protectSize=%d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// End-to-end reproduction of issue #186: writing a 24-byte patch whose tail
+// spills into an adjacent, non-writable page must not crash. Runs in a child
+// process because a SIGBUS from a bad write cannot be recovered.
+func TestModifyBinaryAcrossPageBoundary(t *testing.T) {
+	if os.Getenv("GOMONKEY_REPRO_186") == "1" {
+		reproCrossPageWrite()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestModifyBinaryAcrossPageBoundary$")
+	cmd.Env = append(os.Environ(), "GOMONKEY_REPRO_186=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("modifyBinary crashed on a cross-page write (issue #186): %v\n%s", err, out)
+	}
+}
+
+func reproCrossPageWrite() {
+	ps := syscall.Getpagesize()
+	// Two consecutive pages, both writable to start with...
+	mem, err := syscall.Mmap(-1, 0, 2*ps,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		os.Exit(2)
+	}
+	base := PtrOf(mem)
+	// ...then revoke write on the SECOND page, so a cross-page write faults.
+	if _, _, e := syscall.Syscall(syscall.SYS_MPROTECT,
+		base+uintptr(ps), uintptr(ps), uintptr(syscall.PROT_READ)); e != 0 {
+		os.Exit(2)
+	}
+	// target sits 16 bytes before the boundary -> a 24-byte patch spills 8
+	// bytes into the read-only second page.
+	target := base + uintptr(ps) - 16
+	modifyBinary(target, make([]byte, 24)) // SIGBUS here before the fix
+	os.Exit(0)
+}


### PR DESCRIPTION
modifyBinary only made a single page writable via mprotect. When the
entry address sits within the last 16 bytes before a 16KB page boundary,
the 24-byte patch spills into the next page, which stays read-only and
triggers SIGBUS on darwin.

Compute the start and end page of the write range, and extend
protectSize to cover both pages when the write spans a page boundary.

Closes #186