### PR TITLE
fix(darwin): prevent arm64 patch memory corruption

### DIFF
--- a/modify_binary_darwin.go
+++ b/modify_binary_darwin.go
@@ -12,12 +12,29 @@ func PtrOf(val []byte) uintptr {
 }
 
 func modifyBinary(target uintptr, bytes []byte) {
+	pageSize := syscall.Getpagesize()
+	if err := validateWritePageSize(pageSize); err != nil {
+		panic(err)
+	}
+
 	targetPage := pageStart(target)
 	res := write(target, PtrOf(bytes), len(bytes), targetPage,
 		protectSize(target, len(bytes)), syscall.PROT_READ|syscall.PROT_EXEC)
 	if res != 0 {
 		panic(fmt.Errorf("failed to write memory, code %v", res))
 	}
+}
+
+// validateWritePageSize ensures that write's static assembly padding is wide
+// enough to keep its executable instructions outside the page being modified.
+// Without this check, a larger page size could make write remove execute
+// permission from its own current page and terminate the process with SIGBUS.
+func validateWritePageSize(pageSize int) error {
+	if pageSize > writeIsolationSize {
+		return fmt.Errorf("unsupported system page size %d: write isolation supports at most %d bytes",
+			pageSize, writeIsolationSize)
+	}
+	return nil
 }
 
 // protectSize returns the number of bytes that must be made writable so that a

--- a/modify_binary_darwin_test.go
+++ b/modify_binary_darwin_test.go
@@ -3,9 +3,25 @@ package gomonkey
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 )
+
+func TestValidateWritePageSize(t *testing.T) {
+	if err := validateWritePageSize(writeIsolationSize); err != nil {
+		t.Fatalf("supported page size was rejected: %v", err)
+	}
+
+	unsupported := writeIsolationSize * 2
+	err := validateWritePageSize(unsupported)
+	if err == nil {
+		t.Fatalf("page size %d should be rejected", unsupported)
+	}
+	if !strings.Contains(err.Error(), "unsupported system page size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 // A 24-byte jmp patch that begins close to the end of a page must make both
 // the current and the next page writable, otherwise writing it triggers SIGBUS

--- a/patch.go
+++ b/patch.go
@@ -10,10 +10,12 @@ import (
 )
 
 type Patches struct {
-	originals    map[uintptr][]byte
-	targets      map[uintptr]uintptr
-	values       map[reflect.Value]reflect.Value
-	valueHolders map[reflect.Value]reflect.Value
+	originals                map[uintptr][]byte
+	targets                  map[uintptr]uintptr
+	privateTargets           map[uintptr][]byte
+	privateTargetTrampolines map[uintptr]uintptr
+	values                   map[reflect.Value]reflect.Value
+	valueHolders             map[reflect.Value]reflect.Value
 }
 
 type Params []interface{}
@@ -71,8 +73,14 @@ func ApplyFuncVarReturn(target interface{}, output ...interface{}) *Patches {
 }
 
 func create() *Patches {
-	return &Patches{originals: make(map[uintptr][]byte), targets: map[uintptr]uintptr{},
-		values: make(map[reflect.Value]reflect.Value), valueHolders: make(map[reflect.Value]reflect.Value)}
+	return &Patches{
+		originals:                make(map[uintptr][]byte),
+		targets:                  make(map[uintptr]uintptr),
+		privateTargets:           make(map[uintptr][]byte),
+		privateTargetTrampolines: make(map[uintptr]uintptr),
+		values:                   make(map[reflect.Value]reflect.Value),
+		valueHolders:             make(map[reflect.Value]reflect.Value),
+	}
 }
 
 func NewPatches() *Patches {
@@ -86,6 +94,9 @@ func (this *Patches) Origin(fn func()) {
 	fn()
 	for target, targetPtr := range this.targets {
 		code := buildJmpDirective(targetPtr)
+		modifyBinary(target, code)
+	}
+	for target, code := range this.privateTargets {
 		modifyBinary(target, code)
 	}
 }
@@ -218,6 +229,12 @@ func (this *Patches) Reset() {
 	for target, variable := range this.values {
 		target.Elem().Set(variable)
 	}
+
+	for target, trampoline := range this.privateTargetTrampolines {
+		releasePrivateMethodTrampoline(trampoline)
+		delete(this.privateTargetTrampolines, target)
+		delete(this.privateTargets, target)
+	}
 }
 
 func (this *Patches) ApplyCore(target, double reflect.Value) *Patches {
@@ -237,11 +254,16 @@ func (this *Patches) ApplyCoreOnlyForPrivateMethod(target unsafe.Pointer, double
 		panic("double is not a func")
 	}
 	assTarget := *(*uintptr)(target)
-	original := replace(assTarget, uintptr(getPointer(double)))
+	code, trampoline := buildPrivateMethodDirective(assTarget, uintptr(getPointer(double)),
+		this.privateTargetTrampolines[assTarget])
+	original := replaceByCode(assTarget, code)
 	if _, ok := this.originals[assTarget]; !ok {
 		this.originals[assTarget] = original
 	}
-	this.targets[assTarget] = uintptr(getPointer(double))
+	this.privateTargets[assTarget] = code
+	if trampoline != 0 {
+		this.privateTargetTrampolines[assTarget] = trampoline
+	}
 	this.valueHolders[double] = double
 	return this
 }
@@ -288,7 +310,10 @@ func (this *Patches) check(target, double reflect.Value) {
 }
 
 func replace(target, double uintptr) []byte {
-	code := buildJmpDirective(double)
+	return replaceByCode(target, buildJmpDirective(double))
+}
+
+func replaceByCode(target uintptr, code []byte) []byte {
 	bytes := entryAddress(target, len(code))
 	original := make([]byte, len(bytes))
 	copy(original, bytes)

--- a/private_method_darwin_arm64.go
+++ b/private_method_darwin_arm64.go
@@ -1,0 +1,96 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+package gomonkey
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+)
+
+const (
+	privateMethodTrampolineSize  = 24
+	privateMethodTrampolineCount = 128
+	arm64BranchRange             = 128 * 1024 * 1024
+)
+
+var privateMethodTrampolines struct {
+	sync.Mutex
+	used [privateMethodTrampolineCount]bool
+}
+
+// privateMethodTrampolineBase returns the address of the executable slot area
+// declared in private_method_darwin_arm64.s.
+func privateMethodTrampolineBase() uintptr
+
+func buildPrivateMethodDirective(target, double, trampoline uintptr) ([]byte, uintptr) {
+	acquired := false
+	if trampoline == 0 {
+		trampoline = acquirePrivateMethodTrampoline()
+		acquired = true
+	}
+	completed := false
+	defer func() {
+		if acquired && !completed {
+			releasePrivateMethodTrampoline(trampoline)
+		}
+	}()
+
+	code, err := buildArm64BranchDirective(target, trampoline)
+	if err != nil {
+		panic(err)
+	}
+
+	// Keep the complete 24-byte function-value jump in an isolated executable
+	// slot. The target itself only receives one 4-byte B instruction, so a short
+	// method cannot overwrite the function laid out immediately after it.
+	modifyBinary(trampoline, buildJmpDirective(double))
+	completed = true
+	return code, trampoline
+}
+
+func buildArm64BranchDirective(from, to uintptr) ([]byte, error) {
+	delta := int64(to) - int64(from)
+	if delta%4 != 0 || delta < -arm64BranchRange || delta >= arm64BranchRange {
+		return nil, fmt.Errorf("private method trampoline %#x is out of ARM64 branch range from target %#x", to, from)
+	}
+
+	instruction := uint32(0x14000000) | (uint32(delta>>2) & 0x03ffffff)
+	code := make([]byte, 4)
+	binary.LittleEndian.PutUint32(code, instruction)
+	return code, nil
+}
+
+func acquirePrivateMethodTrampoline() uintptr {
+	privateMethodTrampolines.Lock()
+	defer privateMethodTrampolines.Unlock()
+
+	base := privateMethodTrampolineBase()
+	for i := range privateMethodTrampolines.used {
+		if !privateMethodTrampolines.used[i] {
+			privateMethodTrampolines.used[i] = true
+			return base + uintptr(i*privateMethodTrampolineSize)
+		}
+	}
+	panic(fmt.Sprintf("private method trampoline capacity exceeded: %d active patches", privateMethodTrampolineCount))
+}
+
+func releasePrivateMethodTrampoline(trampoline uintptr) {
+	base := privateMethodTrampolineBase()
+	if trampoline < base {
+		return
+	}
+	offset := trampoline - base
+	if offset%privateMethodTrampolineSize != 0 {
+		return
+	}
+	index := offset / privateMethodTrampolineSize
+	if index >= privateMethodTrampolineCount {
+		return
+	}
+
+	privateMethodTrampolines.Lock()
+	privateMethodTrampolines.used[index] = false
+	privateMethodTrampolines.Unlock()
+}

--- a/private_method_darwin_arm64.s
+++ b/private_method_darwin_arm64.s
@@ -1,0 +1,23 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+#include "textflag.h"
+
+#define NOP8 WORD $0x1f2003d5; WORD $0x1f2003d5;
+#define NOP24 NOP8; NOP8; NOP8;
+#define NOP192 NOP24; NOP24; NOP24; NOP24; NOP24; NOP24; NOP24; NOP24;
+#define NOP1536 NOP192; NOP192; NOP192; NOP192; NOP192; NOP192; NOP192; NOP192;
+
+// privateMethodTrampolineBase exposes the exact start of the executable slot
+// area. Returning the address from assembly avoids an ABI wrapper changing the
+// address observed by Go.
+TEXT ·privateMethodTrampolineBase(SB),NOSPLIT,$0-8
+	MOVD $privateMethodTrampolineSpace<>(SB), R0
+	MOVD R0, ret+0(FP)
+	RET
+
+// 128 fixed-size slots. Each slot holds one 24-byte buildJmpDirective result.
+TEXT privateMethodTrampolineSpace<>(SB),NOSPLIT|NOFRAME,$0-0
+	NOP1536
+	NOP1536
+	RET

--- a/private_method_darwin_arm64_test.go
+++ b/private_method_darwin_arm64_test.go
@@ -1,0 +1,33 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+package gomonkey
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestBuildArm64BranchDirective(t *testing.T) {
+	from := uintptr(0x100000000)
+	to := from + 0x100
+	code, err := buildArm64BranchDirective(from, to)
+	if err != nil {
+		t.Fatalf("buildArm64BranchDirective returned an error: %v", err)
+	}
+	if len(code) != 4 {
+		t.Fatalf("branch directive has length %d, want 4", len(code))
+	}
+
+	instruction := binary.LittleEndian.Uint32(code)
+	if got := instruction & 0xfc000000; got != 0x14000000 {
+		t.Fatalf("branch opcode is %#x, want %#x", got, uint32(0x14000000))
+	}
+	if got := instruction & 0x03ffffff; got != uint32((to-from)/4) {
+		t.Fatalf("branch offset is %#x, want %#x", got, uint32((to-from)/4))
+	}
+
+	if _, err := buildArm64BranchDirective(from, from+arm64BranchRange); err == nil {
+		t.Fatal("out-of-range branch should be rejected")
+	}
+}

--- a/private_method_default.go
+++ b/private_method_default.go
@@ -1,0 +1,10 @@
+//go:build !darwin || !arm64
+// +build !darwin !arm64
+
+package gomonkey
+
+func buildPrivateMethodDirective(_, double, _ uintptr) ([]byte, uintptr) {
+	return buildJmpDirective(double), 0
+}
+
+func releasePrivateMethodTrampoline(uintptr) {}

--- a/test/apply_private_method_test.go
+++ b/test/apply_private_method_test.go
@@ -54,3 +54,24 @@ func TestApplyPrivateMethod(t *testing.T) {
 	})
 
 }
+
+func TestApplyPrivateMethodWithClosure(t *testing.T) {
+	Convey("patch private method with a closure", t, func() {
+		f := new(fake.PrivateMethodStruct)
+		var s *fake.PrivateMethodStruct
+		patchedResult := false
+		patches := ApplyPrivateMethod(s, "ok", func(_ *fake.PrivateMethodStruct) bool {
+			return patchedResult
+		})
+		defer patches.Reset()
+
+		So(f.Happy(), ShouldEqual, "unhappy")
+
+		var originResult string
+		patches.Origin(func() {
+			originResult = f.Happy()
+		})
+		So(originResult, ShouldEqual, "happy")
+		So(f.Happy(), ShouldEqual, "unhappy")
+	})
+}

--- a/write_darwin_amd64.go
+++ b/write_darwin_amd64.go
@@ -1,0 +1,6 @@
+package gomonkey
+
+// writeIsolationSize must match the NOP padding around START in
+// write_darwin_amd64.s. Darwin AMD64 currently uses 4 KiB pages; larger pages
+// are rejected before write changes code-page permissions.
+const writeIsolationSize = 4 * 1024

--- a/write_darwin_amd64.s
+++ b/write_darwin_amd64.s
@@ -16,6 +16,9 @@
 
 #include "textflag.h"
 
+// Keep this 4 KiB padding in sync with writeIsolationSize in
+// write_darwin_amd64.go. Larger runtime page sizes are rejected in Go before
+// any page protection is changed.
 #define NOP8 BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90; BYTE $0x90;
 #define NOP64 NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8;
 #define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;

--- a/write_darwin_arm64.go
+++ b/write_darwin_arm64.go
@@ -1,0 +1,7 @@
+package gomonkey
+
+// writeIsolationSize must match the NOP padding around START in
+// write_darwin_arm64.s. Current Apple Silicon Macs use 16 KiB pages. The
+// runtime check in validateWritePageSize fails safely if a future Darwin ARM64
+// system reports a larger page instead of allowing an in-page SIGBUS.
+const writeIsolationSize = 16 * 1024

--- a/write_darwin_arm64.s
+++ b/write_darwin_arm64.s
@@ -16,10 +16,15 @@
 
 #include "textflag.h"
 
-#define NOP64 WORD $0x1f2003d5; WORD $0x1f2003d5;
+// Keep this 16 KiB padding in sync with writeIsolationSize in
+// write_darwin_arm64.go. It separates write's executable body from adjacent Go
+// text by one supported page; larger runtime page sizes are rejected in Go
+// before any page protection is changed.
+#define NOP8 WORD $0x1f2003d5; WORD $0x1f2003d5;
+#define NOP64 NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8; NOP8;
 #define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
 #define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
-#define NOP16384 NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096; NOP4096;
+#define NOP16384 NOP4096; NOP4096; NOP4096; NOP4096;
 
 #define protRW $(0x1|0x2|0x10)
 #define mProtect $(0x2000000+74)


### PR DESCRIPTION
## Summary

This PR hardens runtime patching on macOS ARM64 and fixes two independent memory-corruption failures.

### Same-page SIGBUS

The write routine temporarily removes execute permission from a code page while patching it. The previous ARM64 NOP macros provided only 4 KiB of effective isolation on systems with 16 KiB pages, so the routine could make its own active page non-executable and crash with SIGBUS.

This change:

- makes the ARM64 padding byte-accurate for 16 KiB pages;
- validates the runtime page size before changing code-page permissions;
- keeps the write routine isolated from the page being modified;
- adds regression coverage for the page-size guard.

### Short private-method corruption

`ApplyPrivateMethod` previously wrote the full 24-byte ARM64 jump directly into the target method. A private method can be only 16 bytes, so the patch could overwrite the beginning of the adjacent method, corrupt return values, and eventually crash with SIGSEGV.

This change:

- writes a single 4-byte ARM64 `B` instruction at the private method entry;
- stores the complete 24-byte function-value jump in an isolated executable trampoline;
- preserves closure context for replacement functions;
- tracks trampolines across repeated patches, `Origin`, and `Reset`;
- leaves non-Darwin/ARM64 patch generation unchanged.

## Verification

- Go 1.22 Darwin/ARM64: `go test ./... -count=1 -gcflags=all=-l`
- Go 1.24 Darwin/ARM64: `go test ./... -count=1 -gcflags=all=-l`
- Go 1.24 Darwin/AMD64 under Rosetta: `go test ./... -count=1 -gcflags=all=-l`
- Added regression tests for ARM64 branch encoding, private-method closures, repeated patching, `Origin`, and `Reset`

Related to #169.
